### PR TITLE
removed [0-9] from the kernel options in the rules file to recognize …

### DIFF
--- a/99-local.rules.usb-mount
+++ b/99-local.rules.usb-mount
@@ -1,3 +1,2 @@
-KERNEL=="sd[a-z]*[0-9]", SUBSYSTEMS=="usb", ACTION=="add", RUN+="/bin/systemctl start usb-mount@%k.service"
-
-KERNEL=="sd[a-z]*[0-9]", SUBSYSTEMS=="usb", ACTION=="remove", RUN+="/bin/systemctl stop usb-mount@%k.service"
+KERNEL=="sd[a-z]*", SUBSYSTEMS=="usb", ACTION=="add", RUN+="/bin/systemctl start usb-mount@%k.service"
+KERNEL=="sd[a-z]*", SUBSYSTEMS=="usb", ACTION=="remove", RUN+="/bin/systemctl stop usb-mount@%k.service"


### PR DESCRIPTION
…"whole disk" formatted devices that don't carry a partition table like the Calliope MINI.